### PR TITLE
Fix rosdep dependencies and humble build

### DIFF
--- a/ranger_base/CMakeLists.txt
+++ b/ranger_base/CMakeLists.txt
@@ -46,12 +46,12 @@ set(DEPENDENCIES
   "tf2_geometry_msgs"
 )
 
-add_executable(ranger_base_node 
+add_executable(ranger_base_node
     src/ranger_base_node.cpp
     src/ranger_messenger.cpp)
 
-target_link_libraries(ranger_base_node ugv_sdk ${dependencies})
-ament_target_dependencies(ranger_base_node rclcpp tf2 tf2_ros std_msgs nav_msgs sensor_msgs ranger_msgs ${dependencies})
+target_link_libraries(ranger_base_node ugv_sdk)
+ament_target_dependencies(ranger_base_node ${DEPENDENCIES})
 
 install(TARGETS ranger_base_node
   DESTINATION lib/${PROJECT_NAME})
@@ -85,4 +85,3 @@ ament_package()
 # target_include_directories(ascent INTERFACE
 # 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 # 	$<INSTALL_INTERFACE:include>)
-

--- a/ranger_base/include/ranger_base/ranger_messenger.hpp
+++ b/ranger_base/include/ranger_base/ranger_messenger.hpp
@@ -25,7 +25,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <geometry_msgs/msg/twist.hpp>
 #include <tf2_ros/transform_broadcaster.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <sensor_msgs/msg/battery_state.hpp>
 
 //third libaray inclue
@@ -103,7 +103,7 @@ class RangerROSMessenger : public std::enable_shared_from_this<RangerROSMessenge
   rclcpp::Publisher<ranger_msgs::msg::ActuatorStateArray>::SharedPtr actuator_state_pub_;
   rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odom_pub_;
   rclcpp::Publisher<sensor_msgs::msg::BatteryState>::SharedPtr battery_state_pub_;
-  
+
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr motion_cmd_sub_;
 
   std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;

--- a/ranger_base/package.xml
+++ b/ranger_base/package.xml
@@ -20,6 +20,7 @@
   <depend>ugv_sdk</depend>
   <depend>ranger_msgs</depend>
   <depend>boost</depend>
+  <depend>controller_manager</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
Fix dependencies installation with rosdep
------------------------------------------------------------
Controller-manager was missing from the dependencies

Fix humble build
------------------------
Dependencies were not properly linked in the CMakeLists
tf2 .h header was deprecated